### PR TITLE
fix: API compatibility in Qt 5.11.x

### DIFF
--- a/src/dbluetoothdevice.cpp
+++ b/src/dbluetoothdevice.cpp
@@ -146,8 +146,10 @@ QBluetoothDeviceInfo DDevice::deviceInfo() const
     info.setRssi(d->m_device->RSSI());
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     info.setServiceUuids(uuidList);
-#else
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
     info.setServiceUuids(uuidList.toVector());
+#else
+    info.setServiceUuids(uuidList, QBluetoothDeviceInfo::DataComplete);
 #endif
     return info;
 }


### PR DESCRIPTION
SetServiceUuids changed since Qt 5.13 and then changed again since Qt 6.0. Check Qt version to support different version of API.

Log: fix API compatibility in Qt 5.11.x